### PR TITLE
add ability to search shortcuts

### DIFF
--- a/menu/Sources/menu/RuntimeArgs.swift
+++ b/menu/Sources/menu/RuntimeArgs.swift
@@ -86,7 +86,8 @@ class RuntimeArgs {
                 advance()
                 if let arg = current {
                     advance()
-                    query = arg.folding(options: [.diacriticInsensitive, .caseInsensitive, .widthInsensitive], locale: nil)
+                    query = arg.folding(options: [.diacriticInsensitive, .caseInsensitive, .widthInsensitive], locale: nil);
+                    query = parseToShortcut(from: query)
                 }
 
             case "-max-depth":
@@ -191,4 +192,69 @@ class RuntimeArgs {
             }
         }
     }
+}
+
+func parseToShortcut(from _term: String) -> String {
+    if !_term.hasPrefix("#") || _term.count < 2{
+        return _term
+    } 
+    var term = String(_term.dropFirst()).split(separator: " ").map(String.init)
+    var res = [String]()
+
+    let keys: [(String, String)] = [
+        ("ctrl", "⌃"),
+        ("alt", "⌥"),
+        ("shift", "⇧"),
+        ("cmd", "⌘"),
+        ("ret", "↩"),
+        ("kp_ent", "⌤"),
+        ("kp_clr", "⌧"),
+        ("tab", "⇥"),
+        ("space", "␣"),
+        ("del", "⌫"),
+        ("esc", "⎋"),
+        ("caps", "⇪"),
+        ("fn", "fn"),
+        ("f1", "F1"),
+        ("f2", "F2"),
+        ("f3", "F3"),
+        ("f4", "F4"),
+        ("f5", "F5"),
+        ("f6", "F6"),
+        ("f7", "F7"),
+        ("f8", "F8"),
+        ("f9", "F9"),
+        ("f10", "F10"),
+        ("f11", "F11"),
+        ("f12", "F12"),
+        ("f13", "F13"),
+        ("f14", "F14"),
+        ("f15", "F15"),
+        ("f16", "F16"),
+        ("f17", "F17"),
+        ("f18", "F18"),
+        ("f19", "F19"),
+        ("f20", "F20"),
+        ("home", "↖"),
+        ("pgup", "⇞"),
+        ("fwd_del", "⌦"),
+        ("end", "↘"),
+        ("pgdn", "⇟"),
+        ("left", "◀︎"),
+        ("right", "▶︎"),
+        ("down", "▼"),
+        ("up", "▲")
+    ]
+
+    for (keycode, key) in keys {
+        if let index = term.firstIndex(of: keycode) {
+            res.append(key); term.remove(at: index)
+        }
+    }
+   
+    if !term.isEmpty {
+        res.append(term.joined(separator: halfWidthSpace))
+    }
+    
+    return res.joined(separator: halfWidthSpace)
 }

--- a/menu/Sources/menu/main.swift
+++ b/menu/Sources/menu/main.swift
@@ -146,11 +146,28 @@ func render(_ menu: MenuItem) {
         $0.icon.type = apple ? "" : "fileicon"
     })
 }
-
 let r = render // prevent swiftc compiler segfault
+
+func transferToShortcut(from term: inout String) -> () {
+    if !term.hasPrefix("#") || term.count < 2{
+        return
+    } 
+    term = String(term.dropFirst())
+    var res = [String]()
+    if term.contains("ctrl") { res.append("⌃") }
+    if term.contains("alt") { res.append("⌥") }
+    if term.contains("shift") { res.append("⇧") }
+    if term.contains("cmd") { res.append("⌘") }
+    if term.split(separator: " ").last!.count == 1 {
+        term = res.joined(separator: halfWidthSpace) + halfWidthSpace + term.split(separator: " ").last!
+    } else {
+        term = res.joined(separator: halfWidthSpace)
+    }
+}
 
 if !args.query.isEmpty {
     let term = args.query.lowercased()
+    transferToShortcut(from: &term)
     let rankedMenuItems: [(MenuItem, Int)] =
         menuItems
             .lazy
@@ -165,7 +182,7 @@ if !args.query.isEmpty {
                 // for the last item alone, do a fuzzy match
                 // along with normal ranked search
                 var level = menu.path.count - 1
-                let name = menu.searchPath[level].lowercased()
+                let name = menu.searchPath[level].lowercased() + " " + menu.shortcut.lowercased()
                 let rank = name.textMatch(term: term)
                 var rankAdjust = 4096
                 if rank == 100 {

--- a/menu/Sources/menu/main.swift
+++ b/menu/Sources/menu/main.swift
@@ -148,26 +148,8 @@ func render(_ menu: MenuItem) {
 }
 let r = render // prevent swiftc compiler segfault
 
-func transferToShortcut(from term: inout String) -> () {
-    if !term.hasPrefix("#") || term.count < 2{
-        return
-    } 
-    term = String(term.dropFirst())
-    var res = [String]()
-    if term.contains("ctrl") { res.append("⌃") }
-    if term.contains("alt") { res.append("⌥") }
-    if term.contains("shift") { res.append("⇧") }
-    if term.contains("cmd") { res.append("⌘") }
-    if term.split(separator: " ").last!.count == 1 {
-        term = res.joined(separator: halfWidthSpace) + halfWidthSpace + term.split(separator: " ").last!
-    } else {
-        term = res.joined(separator: halfWidthSpace)
-    }
-}
-
 if !args.query.isEmpty {
-    let term = args.query.lowercased()
-    transferToShortcut(from: &term)
+    let term = args.query
     let rankedMenuItems: [(MenuItem, Int)] =
         menuItems
             .lazy


### PR DESCRIPTION
To be able to search shortcuts is important for me in case I need to assign some global shortcut to my Alfred workflow, I have to check whether the shortcut is used by my most commonly used apps.

The short cut searching starts from the symbol `#`, 4 mac modifier keys `cmd, shift, alt, ctrl` can appear at any order and separated by space, the single key must be at the last position (`o` for example in the image)

<img width="626" alt="image" src="https://user-images.githubusercontent.com/10261662/217188909-a35c283f-6ef7-4495-bb04-b8c80a45f3f0.png">

Also, it is possible to search shortcuts with only modifier keys
<img width="366" alt="image" src="https://user-images.githubusercontent.com/10261662/217189039-aa520f68-e516-4d3d-a98e-82fac8c9888f.png">

